### PR TITLE
wait less time before notifying the speaker

### DIFF
--- a/daily_jobs.py
+++ b/daily_jobs.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     for talk in talks:
         # Select the talks from yesterday
         if not(
-            datetime.timedelta(days=2) > today - talk["time"] > datetime.timedelta(days=1)
+            datetime.timedelta(days=1) > today - talk["time"] > datetime.timedelta()
         ):
             continue
 


### PR DESCRIPTION
We're now waiting for almost 2 days before emailing the speaker, this reduces it to 1 day. I'm opening this as draft for the notification to the speakers' corner talk from 2 days ago to go out (should happen tonight).